### PR TITLE
Support Tcl 8.6. Prevent loading of bytecode across major versions

### DIFF
--- a/cmpInt.h
+++ b/cmpInt.h
@@ -62,6 +62,7 @@ Tcl_FetchInternalRep(Tcl_Obj *objPtr, const Tcl_ObjType *type) {
         (Tcl_ObjInternalRep *)(&objPtr->internalRep)
         : NULL;
 }
+
 static inline void
 Tcl_FreeInternalRep(Tcl_Obj *objPtr) {
     if (objPtr->typePtr != NULL) {
@@ -71,6 +72,19 @@ Tcl_FreeInternalRep(Tcl_Obj *objPtr) {
 	objPtr->typePtr = NULL;
     }
 }
+
+static inline void
+Tcl_StoreInternalRep(Tcl_Obj *objPtr, const Tcl_ObjType *typePtr,
+                        const Tcl_ObjInternalRep *irPtr) {
+    Tcl_FreeInternalRep(objPtr);
+    /* When irPtr == NULL, just leave objPtr with no internalrep for typePtr */
+    if (irPtr) {
+        objPtr->internalRep.twoPtrValue.ptr1 = irPtr->twoPtrValue.ptr1;
+        objPtr->internalRep.twoPtrValue.ptr2 = irPtr->twoPtrValue.ptr2;
+        objPtr->typePtr = typePtr;
+    }
+}
+
 #endif /* TCL_MAJOR_VERSION < 8 */
 
 /*

--- a/cmpRPkg.c
+++ b/cmpRPkg.c
@@ -25,7 +25,7 @@ static char procCommand[] = CMP_PROC_COMMAND; /* "bcproc"  */
 typedef struct CmdTable
 {
     const char* cmdName;   /* unqualified, e.g. "bceval" */
-    Tcl_ObjCmdProc2* proc; /* implementation */
+    Tcl_ObjCmdProc* proc; /* implementation */
     int exportIt;          /* nonzero => export */
 } CmdTable;
 
@@ -62,7 +62,7 @@ static int RegisterCommand(Tcl_Interp* interp, const char* nsName, const CmdTabl
     Tcl_DStringAppend(&fq, "::", 2);
     Tcl_DStringAppend(&fq, cmd->cmdName, -1);
 
-    Tcl_CreateObjCommand2(interp, Tcl_DStringValue(&fq), cmd->proc, NULL, NULL);
+    Tcl_CreateObjCommand(interp, Tcl_DStringValue(&fq), cmd->proc, NULL, NULL);
     Tcl_DStringFree(&fq);
 
     if (cmd->exportIt)
@@ -89,12 +89,12 @@ int Tbcload_SafeInit(Tcl_Interp* interp)
 static int TbcloadInitInternal(Tcl_Interp* interp, int isSafe)
 {
 #ifdef USE_TCL_STUBS
-    if (!Tcl_InitStubs(interp, "9.0", 1))
+    if (!Tcl_InitStubs(interp, TCL_VERSION, 1))
     {
         return TCL_ERROR;
     }
 #else
-    if (Tcl_PkgRequire(interp, "Tcl", "9.0", 1) == NULL)
+    if (Tcl_PkgRequire(interp, "Tcl", TCL_VERSION, 1) == NULL)
     {
         return TCL_ERROR;
     }

--- a/proTbcLoad.h
+++ b/proTbcLoad.h
@@ -28,8 +28,8 @@
  *----------------------------------------------------------------
  */
 
-EXTERN int Tbcload_EvalObjCmd(void* dummy, Tcl_Interp* interp, Tcl_Size objc, Tcl_Obj* const objv[]);
-EXTERN int Tbcload_ProcObjCmd(void* dummy, Tcl_Interp* interp, Tcl_Size objc, Tcl_Obj* const objv[]);
+EXTERN Tcl_ObjCmdProc Tbcload_EvalObjCmd;
+EXTERN Tcl_ObjCmdProc Tbcload_ProcObjCmd;
 EXTERN const char* TbcloadGetPackageName(void);
 
 EXTERN int Tbcload_Init(Tcl_Interp* interp);


### PR DESCRIPTION
Adds support for Tcl 8.6. Also prevents loading of bytecode compiled on one version into another version as it causes a segfault.

A decision can be made later as to whether completely drop 8.6 support. For now, tests pass.